### PR TITLE
Add Conductor workspace config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,8 @@ gem "bigdecimal" # required explicitly on Ruby 3.4+ for Liquid/Jekyll
 gem "csv" # required explicitly on Ruby 3.4+ for Jekyll
 gem "base64" # required explicitly on Ruby 3.4+ for safe_yaml/Jekyll
 
-gem "wdm", "~> 0.1.0" if Gem.win_platform?
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
+gem "wdm", "~> 0.1.0", platforms: [:mingw, :mswin, :x64_mingw]
+gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]
 gem "webrick", "~> 1.7" # required for Ruby 3.x (removed from stdlib in 3.0)
 
 # If you have any plugins, put them here!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,10 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
+    eventmachine (1.2.7-x64-mingw32)
+    eventmachine (1.2.7-x86-mingw32)
+    ffi (1.17.3)
+    ffi (1.17.3-arm64-darwin)
     ffi (1.17.3-x64-mingw-ucrt)
     ffi (1.17.3-x86_64-linux-gnu)
     forwardable-extended (2.6.0)
@@ -65,6 +69,8 @@ GEM
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
+    sassc (2.4.0-x64-mingw32)
+      ffi (~> 1.9)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     tzinfo (2.0.6)
@@ -76,7 +82,10 @@ GEM
     webrick (1.9.2)
 
 PLATFORMS
+  arm64-darwin-25
   x64-mingw-ucrt
+  x64-mingw32
+  x86-mingw32
   x86_64-linux
 
 DEPENDENCIES
@@ -101,6 +110,10 @@ CHECKSUMS
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
   em-websocket (0.5.3) sha256=f56a92bde4e6cb879256d58ee31f124181f68f8887bd14d53d5d9a292758c6a8
   eventmachine (1.2.7) sha256=994016e42aa041477ba9cff45cbe50de2047f25dd418eba003e84f0d16560972
+  eventmachine (1.2.7-x64-mingw32) sha256=a2ade29b7f6a32306c1333fb1d1e4b79624dba60740565fca24a5197d09c02d1
+  eventmachine (1.2.7-x86-mingw32) sha256=e09221c37d3ac448d1c0caebda5974a4cd0017c7622bede13f1eed49c7096186
+  ffi (1.17.3) sha256=0e9f39f7bb3934f77ad6feab49662be77e87eedcdeb2a3f5c0234c2938563d4c
+  ffi (1.17.3-arm64-darwin) sha256=0c690555d4cee17a7f07c04d59df39b2fba74ec440b19da1f685c6579bb0717f
   ffi (1.17.3-x64-mingw-ucrt) sha256=5f1d7d067a9a1058ad183dba25b05557cd51c85fc1768c49338eabc1cf242d7c
   ffi (1.17.3-x86_64-linux-gnu) sha256=3746b01f677aae7b16dc1acb7cb3cc17b3e35bdae7676a3f568153fb0e2c887f
   forwardable-extended (2.6.0) sha256=1bec948c469bbddfadeb3bd90eb8c85f6e627a412a3e852acfd7eaedbac3ec97
@@ -126,6 +139,7 @@ CHECKSUMS
   rouge (4.7.0) sha256=dba5896715c0325c362e895460a6d350803dbf6427454f49a47500f3193ea739
   safe_yaml (1.0.5) sha256=a6ac2d64b7eb027bdeeca1851fe7e7af0d668e133e8a88066a0c6f7087d9f848
   sassc (2.4.0) sha256=4c60a2b0a3b36685c83b80d5789401c2f678c1652e3288315a1551d811d9f83e
+  sassc (2.4.0-x64-mingw32) sha256=8773b917cb52c7e92c94d4bf324c1c0be3e50d9092f9f5ed4c3c6e454b451c5e
   terminal-table (3.0.2) sha256=f951b6af5f3e00203fb290a669e0a85c5dd5b051b3b023392ccfd67ba5abae91
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   tzinfo-data (1.2026.1) sha256=4ea36519ae5ae2cf0fad471207a519be006daf42e3b2359ee9e9c53f113609fd

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,8 @@
+{
+  "scripts": {
+    "setup": "export PATH=\"/opt/homebrew/opt/ruby/bin:/usr/local/opt/ruby/bin:$PATH\"; ruby -e 'abort(\"Ruby 3.2+ required; install Ruby 3.x first, for example with: brew install ruby\") unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new(\"3.2.0\")' && BUNDLER_VERSION=$(awk '/^BUNDLED WITH$/{getline; gsub(/^[[:space:]]+/, \"\"); print; exit}' Gemfile.lock) && (gem list -i bundler -v \"$BUNDLER_VERSION\" >/dev/null || gem install bundler -v \"$BUNDLER_VERSION\") && npm ci",
+    "run": "export PATH=\"/opt/homebrew/opt/ruby/bin:/usr/local/opt/ruby/bin:$PATH\"; export BUNDLE_FROZEN=true; ruby -e 'abort(\"Ruby 3.2+ required; install Ruby 3.x first, for example with: brew install ruby\") unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new(\"3.2.0\")' && bundle exec ruby bin/jekyll-local.rb serve --incremental --host 127.0.0.1 --port ${CONDUCTOR_PORT:-4000}",
+    "archive": "export PATH=\"/opt/homebrew/opt/ruby/bin:/usr/local/opt/ruby/bin:$PATH\"; export BUNDLE_FROZEN=true; bundle exec jekyll clean || true"
+  },
+  "runScriptMode": "concurrent"
+}


### PR DESCRIPTION
Adds a shared root conductor.json for setup, run, and archive scripts in Conductor workspaces. The run script uses CONDUCTOR_PORT and frozen Bundler so parallel macOS workspaces can serve Jekyll without mutating lockfiles. Gemfile platform declarations and Gemfile.lock are updated so macOS Conductor runs and Windows-specific dependencies remain represented. Validated locally with JSON parsing, setup, frozen Jekyll serve on CONDUCTOR_PORT, curl HTTP 200, and archive cleanup.