### PR TITLE
Proxy CryptoCompare through Netlify after CoinDesk retired keyless API access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ Jekyll 4.3.4 static site. Content in Liquid templates, styles in SCSS (libsass v
 - **Kraken affiliate**: config in `_config.yml` under `kraken.affiliate_link` / `kraken.affiliate_code`; banner template at `_includes/calculator_affiliate_banner.html`
 - **Google Tag Manager**: GTM-TV5P5BH
 - **Disqus comments**: shortname `criptomo`
-- **Market data**: CryptoCompare and LiveCoinWatch APIs (API contracts tested via `npm run test:api-contracts`)
+- **Market data**: CryptoCompare and LiveCoinWatch APIs (API contracts tested via `npm run test:api-contracts`). CryptoCompare requires an API key since 2026-05-21: browser code must call the Netlify Function proxy at `/api/market/*` (see `netlify/functions/market-data.js` and `netlify.toml`) instead of `min-api.cryptocompare.com` directly. The key lives in the `CRYPTOCOMPARE_API_KEY` Netlify environment variable and GitHub Actions secret — never in the repo or page source.
 
 ## Monetization
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For more information check the [official Jekyll docs](https://jekyllrb.com/docs/
 * Run `npm run test:api-contracts` to verify the current external API contracts used by the repo.
 * The command writes a Markdown and JSON report to `artifacts/api-contracts/`.
 * A separate GitHub Actions workflow in `.github/workflows/live-api-contracts.yml` runs the same checks on a schedule and by manual dispatch, outside the normal PR test path.
-* If CryptoCompare rate limits the scheduled job, add `CRYPTOCOMPARE_API_KEY` as a repository secret.
+* CryptoCompare (CoinDesk Data) requires an API key since 2026-05-21, so the `CRYPTOCOMPARE_API_KEY` repository secret must stay configured for the scheduled job. The script redacts the key from its reports.
 
 ## Collaborate
 

--- a/bin/check-api-contracts.js
+++ b/bin/check-api-contracts.js
@@ -32,6 +32,10 @@ function createCheckError(message, metadata) {
   return Object.assign(new Error(message), metadata);
 }
 
+function redactApiKey(value) {
+  return String(value === null || value === undefined ? '' : value).replace(/(api_key=)[^&\s"']+/gi, '$1REDACTED');
+}
+
 function ensureFetch() {
   if (typeof fetch !== 'function') {
     throw new Error('Global fetch is not available. Run this script with Node 18 or newer.');
@@ -248,7 +252,7 @@ async function runContractChecks(options) {
       const result = await check.run();
       results.push({
         durationMs: result.durationMs,
-        endpoint: result.endpoint,
+        endpoint: redactApiKey(result.endpoint),
         httpStatus: result.httpStatus,
         name: check.name,
         notes: result.notes,
@@ -258,8 +262,8 @@ async function runContractChecks(options) {
     } catch (error) {
       results.push({
         durationMs: null,
-        endpoint: error.endpoint || 'unknown',
-        error: error.message,
+        endpoint: redactApiKey(error.endpoint || 'unknown'),
+        error: redactApiKey(error.message),
         httpStatus: Number.isFinite(error.httpStatus) ? error.httpStatus : null,
         name: check.name,
         notes: '',

--- a/bin/check-page-console-errors.js
+++ b/bin/check-page-console-errors.js
@@ -97,11 +97,17 @@ const PRELUDE_SCRIPT = `<script>
 
   function getStubbedPayload(rawUrl) {
     var url = new URL(rawUrl, window.location.href);
+    var marketProxyPrefix = '/api/market';
+    var isMarketProxyCall = url.hostname === 'min-api.cryptocompare.com'
+      || (url.host === window.location.host && url.pathname.indexOf(marketProxyPrefix + '/') === 0);
+    var marketPath = url.pathname.indexOf(marketProxyPrefix + '/') === 0
+      ? url.pathname.slice(marketProxyPrefix.length)
+      : url.pathname;
 
-    if (url.hostname === 'min-api.cryptocompare.com' && url.pathname === '/data/price') {
+    if (isMarketProxyCall && marketPath === '/data/price') {
       return { status: 200, body: { USD: 50000, EUR: 46000 } };
     }
-    if (url.hostname === 'min-api.cryptocompare.com' && url.pathname === '/data/v2/histoday') {
+    if (isMarketProxyCall && marketPath === '/data/v2/histoday') {
       return {
         status: 200,
         body: {
@@ -116,10 +122,10 @@ const PRELUDE_SCRIPT = `<script>
         }
       };
     }
-    if (url.hostname === 'min-api.cryptocompare.com' && url.pathname === '/data/pricehistorical') {
+    if (isMarketProxyCall && marketPath === '/data/pricehistorical') {
       return { status: 200, body: { BTC: { USD: 48000, EUR: 44000 } } };
     }
-    if (url.hostname === 'min-api.cryptocompare.com' && url.pathname === '/data/pricemulti') {
+    if (isMarketProxyCall && marketPath === '/data/pricemulti') {
       return { status: 200, body: { BTC: { USD: 50000 }, ETH: { USD: 2500 } } };
     }
     if (url.hostname === 'api.coindesk.com' && url.pathname === '/v1/bpi/historical/close.json') {

--- a/docs/investment-dca-api-notes.md
+++ b/docs/investment-dca-api-notes.md
@@ -47,9 +47,9 @@ This matches the rest of the repo's calculator stack and allows a single client-
 
 ### CryptoCompare
 
-- Public endpoints work without a key for the current site behavior.
-- Rate limiting is still a risk. The repo already documents `CRYPTOCOMPARE_API_KEY` for server-side contract checks.
-- For production hardening, the next step would be a Netlify/server proxy that keeps any paid key out of browser source.
+- **Update 2026-06:** CoinDesk Data (CryptoCompare's owner) retired keyless access on 2026-05-21; every `min-api` call now requires an API key. The current free allowance is 11,000 calls/month.
+- Browser code therefore calls the Netlify Function proxy at `/api/market/*` (`netlify/functions/market-data.js`), which appends the key server-side from the `CRYPTOCOMPARE_API_KEY` Netlify environment variable and sets CDN cache headers (5 minutes for current prices, 1 day for historical data) so repeat lookups do not spend quota.
+- The same key is stored as a GitHub Actions secret for the scheduled contract checks; `bin/check-api-contracts.js` redacts it from reports.
 
 ### CoinDesk
 
@@ -58,4 +58,4 @@ This matches the rest of the repo's calculator stack and allows a single client-
 
 ## Main challenge
 
-This repository is a static Jekyll site. Any paid API key placed directly in page JavaScript would be public. That makes browser-safe public endpoints the practical default unless the project adds a proxy layer.
+This repository is a static Jekyll site. Any API key placed directly in page JavaScript would be public. Since CryptoCompare ended keyless access, the project uses the proxy layer described above: pages call same-origin `/api/market/*` routes and the Netlify Function holds the key.

--- a/docs/investment-dca-api-notes.md
+++ b/docs/investment-dca-api-notes.md
@@ -48,7 +48,7 @@ This matches the rest of the repo's calculator stack and allows a single client-
 ### CryptoCompare
 
 - **Update 2026-06:** CoinDesk Data (CryptoCompare's owner) retired keyless access on 2026-05-21; every `min-api` call now requires an API key. The current free allowance is 11,000 calls/month.
-- Browser code therefore calls the Netlify Function proxy at `/api/market/*` (`netlify/functions/market-data.js`), which appends the key server-side from the `CRYPTOCOMPARE_API_KEY` Netlify environment variable and sets CDN cache headers (5 minutes for current prices, 1 day for historical data) so repeat lookups do not spend quota.
+- Browser code therefore calls the Netlify Function proxy at `/api/market/*` (`netlify/functions/market-data.js`), which appends the key server-side from the `CRYPTOCOMPARE_API_KEY` Netlify environment variable and sets CDN cache headers (5 minutes for current prices and same-day history, 1 year + `immutable` for closed past days — Netlify purges its cache on each deploy anyway) so repeat lookups do not spend quota.
 - The same key is stored as a GitHub Actions secret for the scheduled contract checks; `bin/check-api-contracts.js` redacts it from reports.
 
 ### CoinDesk

--- a/js/calculator.js
+++ b/js/calculator.js
@@ -334,7 +334,7 @@ function calculateEarnings() {
     });
     Array.from(document.getElementsByClassName('error')).forEach(el => el.classList.remove('is-visible'));
 
-    fetch('https://min-api.cryptocompare.com/data/price?fsym=' + investment.tokenSymbol + '&tsyms=' + investment.fiat)
+    fetch('/api/market/data/price?fsym=' + investment.tokenSymbol + '&tsyms=' + investment.fiat)
       .then(response => response.json())
       .then((response) => {
         const currentPrice = parseCurrentPriceResponse(response, investment.fiat);
@@ -361,7 +361,7 @@ function calculateEarnings() {
         //     });
         // } else {
           // altcoin api
-          fetch('https://min-api.cryptocompare.com/data/pricehistorical?fsym=' + investment.tokenSymbol + '&tsyms=' + investment.fiat + '&ts=' + timestamp)
+          fetch('/api/market/data/pricehistorical?fsym=' + investment.tokenSymbol + '&tsyms=' + investment.fiat + '&ts=' + timestamp)
             .then(data => data.json())
             .then((data) => {
               const historicalPriceData = parseHistoricalPriceResponse(data, investment.tokenSymbol, investment.fiat);

--- a/js/icos.js
+++ b/js/icos.js
@@ -118,7 +118,7 @@ function calculateIcoGain(currentPrice, icoPrice) {
 
 function marketcapTableLoad() {
   table.processing( true );
-  let getUrl = 'https://min-api.cryptocompare.com/data/pricemulti?fsyms=' + icos.join() + '&tsyms=USD';
+  let getUrl = '/api/market/data/pricemulti?fsyms=' + icos.join() + '&tsyms=USD';
   ICODataArray = [];
 
   $.get( getUrl, function ( response ) {

--- a/js/invest.js
+++ b/js/invest.js
@@ -183,7 +183,7 @@ function buildInvestmentRows(bpi, investmentData) {
 function buildCryptoCompareHistoricalUrl(tokenSymbol, fiat, startDate, endDate) {
   var limit = getCryptoCompareHistodayLimit(startDate, endDate);
   var toTs = Math.floor(parseDateAsUtc(endDate).getTime() / 1000);
-  return 'https://min-api.cryptocompare.com/data/v2/histoday'
+  return '/api/market/data/v2/histoday'
     + '?fsym=' + encodeURIComponent(tokenSymbol)
     + '&tsym=' + encodeURIComponent(fiat)
     + '&limit=' + limit
@@ -376,7 +376,7 @@ function calculateEarnings() {
         return;
       }
 
-      $.get('https://min-api.cryptocompare.com/data/price?fsym=' + encodeURIComponent(investment.tokenSymbol) + '&tsyms=' + encodeURIComponent(investment.fiat))
+      $.get('/api/market/data/price?fsym=' + encodeURIComponent(investment.tokenSymbol) + '&tsyms=' + encodeURIComponent(investment.fiat))
         .success(function (priceData) {
           const latestResult = investmentDataArray[investmentDataArray.length - 1];
           const parsedCurrentPrice = parseCurrentPriceResponse(priceData, investment.fiat);

--- a/js/simulator.js
+++ b/js/simulator.js
@@ -85,7 +85,7 @@ function calculateSimulator() {
 
   showSimulatorLoading();
 
-  var url = 'https://min-api.cryptocompare.com/data/price?fsym=' + encodeURIComponent(coin) + '&tsyms=' + encodeURIComponent(fiat);
+  var url = '/api/market/data/price?fsym=' + encodeURIComponent(coin) + '&tsyms=' + encodeURIComponent(fiat);
 
   fetch(url)
     .then(function(response) {

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,10 @@
+# Build settings live in the Netlify UI; this file only wires the market-data
+# proxy function and its public /api/market/* route.
+
+[functions]
+  directory = "netlify/functions"
+
+[[redirects]]
+  from = "/api/market/*"
+  to = "/.netlify/functions/market-data/:splat"
+  status = 200

--- a/netlify/functions/market-data.js
+++ b/netlify/functions/market-data.js
@@ -1,0 +1,107 @@
+// Netlify Function: server-side proxy for the CryptoCompare (CoinDesk Data) market endpoints.
+//
+// The browser calls /api/market/<path> (see netlify.toml); this function appends the
+// CRYPTOCOMPARE_API_KEY environment variable server-side so the key never reaches
+// page source. CDN cache headers keep repeat lookups from spending API quota:
+// current prices stay fresh within a five-minute window, while historical data
+// never changes and can sit in the durable cache for a day.
+
+const UPSTREAM_ORIGIN = 'https://min-api.cryptocompare.com';
+const ROUTE_PREFIXES = ['/api/market', '/.netlify/functions/market-data'];
+
+const CACHE_PROFILES = {
+  current: {
+    'Cache-Control': 'public, max-age=60',
+    'Netlify-CDN-Cache-Control': 'public, durable, s-maxage=300'
+  },
+  historical: {
+    'Cache-Control': 'public, max-age=3600',
+    'Netlify-CDN-Cache-Control': 'public, durable, s-maxage=86400'
+  }
+};
+
+const ALLOWED_ENDPOINTS = {
+  '/data/price': CACHE_PROFILES.current,
+  '/data/pricemulti': CACHE_PROFILES.current,
+  '/data/pricehistorical': CACHE_PROFILES.historical,
+  '/data/v2/histoday': CACHE_PROFILES.historical
+};
+
+const JSON_CONTENT_TYPE = { 'Content-Type': 'application/json; charset=utf-8' };
+const NO_STORE = { 'Cache-Control': 'no-store' };
+
+function getUpstreamPath(eventPath) {
+  const requestPath = String(eventPath || '');
+  const matchedPrefix = ROUTE_PREFIXES.find(function (prefix) {
+    return requestPath === prefix || requestPath.startsWith(prefix + '/');
+  });
+
+  if (!matchedPrefix) {
+    return requestPath;
+  }
+
+  return requestPath.slice(matchedPrefix.length) || '/';
+}
+
+function buildUpstreamUrl(upstreamPath, queryStringParameters, apiKey) {
+  const url = new URL(upstreamPath, UPSTREAM_ORIGIN);
+  const params = queryStringParameters || {};
+
+  Object.keys(params).forEach(function (key) {
+    if (key.toLowerCase() === 'api_key') {
+      return;
+    }
+    url.searchParams.set(key, params[key]);
+  });
+
+  if (apiKey) {
+    url.searchParams.set('api_key', apiKey);
+  }
+
+  return url.toString();
+}
+
+function jsonError(statusCode, message) {
+  return {
+    statusCode: statusCode,
+    headers: Object.assign({}, JSON_CONTENT_TYPE, NO_STORE),
+    body: JSON.stringify({ error: message })
+  };
+}
+
+async function handler(event) {
+  const upstreamPath = getUpstreamPath(event && event.path);
+  const cacheHeaders = ALLOWED_ENDPOINTS[upstreamPath];
+
+  if (!cacheHeaders) {
+    return jsonError(404, 'Unknown market data endpoint.');
+  }
+
+  const upstreamUrl = buildUpstreamUrl(
+    upstreamPath,
+    event && event.queryStringParameters,
+    process.env.CRYPTOCOMPARE_API_KEY
+  );
+
+  try {
+    const response = await fetch(upstreamUrl);
+    const body = await response.text();
+
+    return {
+      statusCode: response.status,
+      headers: Object.assign({}, JSON_CONTENT_TYPE, response.ok ? cacheHeaders : NO_STORE),
+      body: body
+    };
+  } catch (error) {
+    return jsonError(502, 'Upstream market data request failed.');
+  }
+}
+
+exports.handler = handler;
+
+module.exports = {
+  ALLOWED_ENDPOINTS: ALLOWED_ENDPOINTS,
+  buildUpstreamUrl: buildUpstreamUrl,
+  getUpstreamPath: getUpstreamPath,
+  handler: handler
+};

--- a/netlify/functions/market-data.js
+++ b/netlify/functions/market-data.js
@@ -3,28 +3,54 @@
 // The browser calls /api/market/<path> (see netlify.toml); this function appends the
 // CRYPTOCOMPARE_API_KEY environment variable server-side so the key never reaches
 // page source. CDN cache headers keep repeat lookups from spending API quota:
-// current prices stay fresh within a five-minute window, while historical data
-// never changes and can sit in the durable cache for a day.
+// current prices stay fresh within a five-minute window, while lookups for closed
+// past days never change and can sit in the durable cache for a year. Netlify
+// purges its cache on every deploy, so the long TTL means "until the next deploy",
+// never a staleness risk.
 
 const UPSTREAM_ORIGIN = 'https://min-api.cryptocompare.com';
 const ROUTE_PREFIXES = ['/api/market', '/.netlify/functions/market-data'];
+const YEAR_SECONDS = 31536000;
 
 const CACHE_PROFILES = {
   current: {
     'Cache-Control': 'public, max-age=60',
     'Netlify-CDN-Cache-Control': 'public, durable, s-maxage=300'
   },
-  historical: {
-    'Cache-Control': 'public, max-age=3600',
-    'Netlify-CDN-Cache-Control': 'public, durable, s-maxage=86400'
+  immutableHistory: {
+    'Cache-Control': 'public, max-age=86400, immutable',
+    'Netlify-CDN-Cache-Control': 'public, durable, immutable, s-maxage=' + YEAR_SECONDS
   }
 };
 
+// Data for closed past days is immutable, but a timestamp on the current UTC day
+// still moves with the market (the day's candle is still running), so it only
+// gets the short current-price window. Invalid or missing timestamps mean the
+// upstream defaults to "now" and are treated the same way.
+function historicalCacheProfile(timestampParam) {
+  const timestamp = Number(timestampParam);
+  const startOfTodayUtcSeconds = Math.floor(Date.now() / 86400000) * 86400;
+
+  if (Number.isFinite(timestamp) && timestamp > 0 && timestamp < startOfTodayUtcSeconds) {
+    return CACHE_PROFILES.immutableHistory;
+  }
+
+  return CACHE_PROFILES.current;
+}
+
 const ALLOWED_ENDPOINTS = {
-  '/data/price': CACHE_PROFILES.current,
-  '/data/pricemulti': CACHE_PROFILES.current,
-  '/data/pricehistorical': CACHE_PROFILES.historical,
-  '/data/v2/histoday': CACHE_PROFILES.historical
+  '/data/price': function () {
+    return CACHE_PROFILES.current;
+  },
+  '/data/pricemulti': function () {
+    return CACHE_PROFILES.current;
+  },
+  '/data/pricehistorical': function (params) {
+    return historicalCacheProfile(params.ts);
+  },
+  '/data/v2/histoday': function (params) {
+    return historicalCacheProfile(params.toTs);
+  }
 };
 
 const JSON_CONTENT_TYPE = { 'Content-Type': 'application/json; charset=utf-8' };
@@ -71,15 +97,17 @@ function jsonError(statusCode, message) {
 
 async function handler(event) {
   const upstreamPath = getUpstreamPath(event && event.path);
-  const cacheHeaders = ALLOWED_ENDPOINTS[upstreamPath];
+  const resolveCacheHeaders = ALLOWED_ENDPOINTS[upstreamPath];
 
-  if (!cacheHeaders) {
+  if (!resolveCacheHeaders) {
     return jsonError(404, 'Unknown market data endpoint.');
   }
 
+  const queryStringParameters = (event && event.queryStringParameters) || {};
+  const cacheHeaders = resolveCacheHeaders(queryStringParameters);
   const upstreamUrl = buildUpstreamUrl(
     upstreamPath,
-    event && event.queryStringParameters,
+    queryStringParameters,
     process.env.CRYPTOCOMPARE_API_KEY
   );
 

--- a/tests/api-contracts-script.test.js
+++ b/tests/api-contracts-script.test.js
@@ -66,6 +66,39 @@ describe('live api contract runner', () => {
     expect(apiContracts.formatMarkdownReport(report)).toContain('Overall: FAIL');
   });
 
+  test('never leaks the CryptoCompare API key into reports', async () => {
+    process.env.CRYPTOCOMPARE_API_KEY = 'super-secret-key';
+    global.fetch
+      .mockResolvedValueOnce(createJsonResponse({ USD: 50000 }))
+      .mockResolvedValueOnce(createJsonResponse({ Response: 'Error' }, 401))
+      .mockResolvedValueOnce(createJsonResponse({
+        Data: {
+          Data: [
+            { time: 1741305600, close: 99000 },
+            { time: 1741392000, close: 100000 }
+          ]
+        }
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        data: [{
+          cap: 1000000,
+          circulating: 19000000,
+          code: 'BTC',
+          name: 'Bitcoin',
+          price: 60000,
+          rank: 1
+        }]
+      }));
+
+    const report = await apiContracts.runContractChecks({ now: new Date('2026-03-10T12:00:00.000Z') });
+
+    expect(global.fetch.mock.calls[0][0]).toContain('api_key=super-secret-key');
+    expect(JSON.stringify(report)).not.toContain('super-secret-key');
+    expect(apiContracts.formatMarkdownReport(report)).not.toContain('super-secret-key');
+    expect(apiContracts.formatConsoleReport(report)).not.toContain('super-secret-key');
+    expect(report.results[0].endpoint).toContain('api_key=REDACTED');
+  });
+
   test('formats a readable console report with a fixed-width table', () => {
     const report = {
       generatedAt: '2026-03-10T12:00:00.000Z',

--- a/tests/calculator-and-invest.test.js
+++ b/tests/calculator-and-invest.test.js
@@ -292,7 +292,7 @@ describe('calculator.js and invest.js', () => {
     const invest = loadModule('../js/invest.js');
     invest.calculateEarnings();
 
-    expect($.get).toHaveBeenCalledWith(expect.stringContaining('min-api.cryptocompare.com/data/v2/histoday'));
+    expect($.get).toHaveBeenCalledWith(expect.stringContaining('/api/market/data/v2/histoday'));
     expect($.get).toHaveBeenCalledWith(expect.stringContaining('fsym=ETH'));
     expect($.get).toHaveBeenCalledWith(expect.stringContaining('tsym=USD'));
     expect(table.rows.add).toHaveBeenCalledWith(expect.arrayContaining([

--- a/tests/market-data-function.test.js
+++ b/tests/market-data-function.test.js
@@ -37,10 +37,11 @@ describe('market-data Netlify function', () => {
     expect(JSON.parse(result.body)).toEqual({ USD: 50000 });
   });
 
-  test('caches current prices briefly and historical data for a day', async () => {
+  test('caches current prices briefly and closed past days for a year', async () => {
     global.fetch
       .mockResolvedValueOnce(createUpstreamResponse({ USD: 50000 }))
-      .mockResolvedValueOnce(createUpstreamResponse({ BTC: { USD: 48000 } }));
+      .mockResolvedValueOnce(createUpstreamResponse({ BTC: { USD: 48000 } }))
+      .mockResolvedValueOnce(createUpstreamResponse({ Data: { Data: [] } }));
 
     const current = await marketData.handler({
       path: '/api/market/data/price',
@@ -50,9 +51,45 @@ describe('market-data Netlify function', () => {
       path: '/api/market/data/pricehistorical',
       queryStringParameters: { fsym: 'BTC', ts: '1500000000', tsyms: 'USD' }
     });
+    const dailyHistory = await marketData.handler({
+      path: '/api/market/data/v2/histoday',
+      queryStringParameters: {
+        fsym: 'BTC',
+        tsym: 'USD',
+        limit: '4',
+        toTs: String(Math.floor(Date.now() / 1000) - 3 * 86400)
+      }
+    });
 
     expect(current.headers['Netlify-CDN-Cache-Control']).toContain('s-maxage=300');
-    expect(historical.headers['Netlify-CDN-Cache-Control']).toContain('s-maxage=86400');
+    expect(historical.headers['Netlify-CDN-Cache-Control']).toContain('s-maxage=31536000');
+    expect(historical.headers['Netlify-CDN-Cache-Control']).toContain('immutable');
+    expect(dailyHistory.headers['Netlify-CDN-Cache-Control']).toContain('s-maxage=31536000');
+  });
+
+  test('keeps same-day or invalid historical timestamps on the short cache window', async () => {
+    const startOfTodayUtc = Math.floor(Date.now() / 86400000) * 86400;
+    global.fetch
+      .mockResolvedValueOnce(createUpstreamResponse({ BTC: { USD: 48000 } }))
+      .mockResolvedValueOnce(createUpstreamResponse({ Data: { Data: [] } }))
+      .mockResolvedValueOnce(createUpstreamResponse({ Data: { Data: [] } }));
+
+    const sameDayHistorical = await marketData.handler({
+      path: '/api/market/data/pricehistorical',
+      queryStringParameters: { fsym: 'BTC', ts: String(Math.floor(Date.now() / 1000)), tsyms: 'USD' }
+    });
+    const todayDailyHistory = await marketData.handler({
+      path: '/api/market/data/v2/histoday',
+      queryStringParameters: { fsym: 'BTC', tsym: 'USD', limit: '4', toTs: String(startOfTodayUtc) }
+    });
+    const missingTimestamp = await marketData.handler({
+      path: '/api/market/data/v2/histoday',
+      queryStringParameters: { fsym: 'BTC', tsym: 'USD', limit: '4' }
+    });
+
+    expect(sameDayHistorical.headers['Netlify-CDN-Cache-Control']).toContain('s-maxage=300');
+    expect(todayDailyHistory.headers['Netlify-CDN-Cache-Control']).toContain('s-maxage=300');
+    expect(missingTimestamp.headers['Netlify-CDN-Cache-Control']).toContain('s-maxage=300');
   });
 
   test('strips any client-supplied api_key before calling upstream', async () => {

--- a/tests/market-data-function.test.js
+++ b/tests/market-data-function.test.js
@@ -1,0 +1,129 @@
+const marketData = require('../netlify/functions/market-data.js');
+
+function createUpstreamResponse(payload, status) {
+  const httpStatus = status || 200;
+
+  return {
+    ok: httpStatus >= 200 && httpStatus < 300,
+    status: httpStatus,
+    text: jest.fn().mockResolvedValue(JSON.stringify(payload))
+  };
+}
+
+describe('market-data Netlify function', () => {
+  beforeEach(() => {
+    process.env.CRYPTOCOMPARE_API_KEY = 'server-side-key';
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    delete process.env.CRYPTOCOMPARE_API_KEY;
+  });
+
+  test('proxies an allowed endpoint and appends the server-side api key', async () => {
+    global.fetch.mockResolvedValueOnce(createUpstreamResponse({ USD: 50000 }));
+
+    const result = await marketData.handler({
+      path: '/api/market/data/price',
+      queryStringParameters: { fsym: 'BTC', tsyms: 'USD,EUR' }
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const upstreamUrl = global.fetch.mock.calls[0][0];
+    expect(upstreamUrl).toContain('https://min-api.cryptocompare.com/data/price?');
+    expect(upstreamUrl).toContain('fsym=BTC');
+    expect(upstreamUrl).toContain('api_key=server-side-key');
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toEqual({ USD: 50000 });
+  });
+
+  test('caches current prices briefly and historical data for a day', async () => {
+    global.fetch
+      .mockResolvedValueOnce(createUpstreamResponse({ USD: 50000 }))
+      .mockResolvedValueOnce(createUpstreamResponse({ BTC: { USD: 48000 } }));
+
+    const current = await marketData.handler({
+      path: '/api/market/data/price',
+      queryStringParameters: { fsym: 'BTC', tsyms: 'USD' }
+    });
+    const historical = await marketData.handler({
+      path: '/api/market/data/pricehistorical',
+      queryStringParameters: { fsym: 'BTC', ts: '1500000000', tsyms: 'USD' }
+    });
+
+    expect(current.headers['Netlify-CDN-Cache-Control']).toContain('s-maxage=300');
+    expect(historical.headers['Netlify-CDN-Cache-Control']).toContain('s-maxage=86400');
+  });
+
+  test('strips any client-supplied api_key before calling upstream', async () => {
+    global.fetch.mockResolvedValueOnce(createUpstreamResponse({ USD: 50000 }));
+
+    await marketData.handler({
+      path: '/api/market/data/price',
+      queryStringParameters: { fsym: 'BTC', tsyms: 'USD', api_key: 'client-injected' }
+    });
+
+    const upstreamUrl = global.fetch.mock.calls[0][0];
+    expect(upstreamUrl).not.toContain('client-injected');
+    expect(upstreamUrl).toContain('api_key=server-side-key');
+  });
+
+  test('also resolves paths on the direct function route', async () => {
+    global.fetch.mockResolvedValueOnce(createUpstreamResponse({ Data: { Data: [] } }));
+
+    const result = await marketData.handler({
+      path: '/.netlify/functions/market-data/data/v2/histoday',
+      queryStringParameters: { fsym: 'BTC', tsym: 'USD', limit: '4' }
+    });
+
+    expect(global.fetch.mock.calls[0][0]).toContain('https://min-api.cryptocompare.com/data/v2/histoday?');
+    expect(result.statusCode).toBe(200);
+  });
+
+  test('rejects endpoints outside the allowlist without calling upstream', async () => {
+    const result = await marketData.handler({
+      path: '/api/market/data/blockchain/mining',
+      queryStringParameters: {}
+    });
+
+    expect(result.statusCode).toBe(404);
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(result.headers['Cache-Control']).toBe('no-store');
+  });
+
+  test('passes through upstream errors without caching them', async () => {
+    global.fetch.mockResolvedValueOnce(createUpstreamResponse({ Response: 'Error' }, 429));
+
+    const result = await marketData.handler({
+      path: '/api/market/data/price',
+      queryStringParameters: { fsym: 'BTC', tsyms: 'USD' }
+    });
+
+    expect(result.statusCode).toBe(429);
+    expect(result.headers['Cache-Control']).toBe('no-store');
+  });
+
+  test('returns 502 when the upstream request throws', async () => {
+    global.fetch.mockRejectedValueOnce(new Error('socket hang up'));
+
+    const result = await marketData.handler({
+      path: '/api/market/data/price',
+      queryStringParameters: { fsym: 'BTC', tsyms: 'USD' }
+    });
+
+    expect(result.statusCode).toBe(502);
+    expect(JSON.parse(result.body).error).toContain('Upstream');
+  });
+
+  test('still proxies without a configured api key (local/dev fallback)', async () => {
+    delete process.env.CRYPTOCOMPARE_API_KEY;
+    global.fetch.mockResolvedValueOnce(createUpstreamResponse({ USD: 50000 }));
+
+    await marketData.handler({
+      path: '/api/market/data/price',
+      queryStringParameters: { fsym: 'BTC', tsyms: 'USD' }
+    });
+
+    expect(global.fetch.mock.calls[0][0]).not.toContain('api_key=');
+  });
+});

--- a/tests/provider-branches.test.js
+++ b/tests/provider-branches.test.js
@@ -35,7 +35,7 @@ describe('provider edge branches', () => {
     expect(document.getElementById('invest-fiat').value).toBe('USD');
     expect(document.getElementById('invest-currency').value).toBe('BTC');
     expect(document.getElementById('invest-interval').value).toBe('30');
-    expect($.get).toHaveBeenCalledWith(expect.stringContaining('min-api.cryptocompare.com/data/v2/histoday'));
+    expect($.get).toHaveBeenCalledWith(expect.stringContaining('/api/market/data/v2/histoday'));
     expect($.get).toHaveBeenCalledWith(expect.stringContaining('fsym=BTC'));
 
     buildInvestDom();


### PR DESCRIPTION
## Problem

CoinDesk Data (CryptoCompare's owner) [retired keyless API access on 2026-05-21](https://data.coindesk.com/blogs/changes-to-coindesk-data-indices-api-free-tier-access). Every `min-api.cryptocompare.com` call now returns HTTP 401, which broke:

- `/calculadora/` (current + historical price) and localized variants
- `/inversion/` DCA calculator (daily history) and localized variants
- `/simulador/` (current price) and localized variants
- `/icos/` (multi-coin prices)
- The daily `live-api-contracts` workflow (e.g. [run 27198662384](https://github.com/DannieBGoode/criptomo/actions/runs/27198662384))

A free CoinDesk Data key (11,000 calls/month) works on the legacy endpoints, but this is a static site — a key in page JavaScript would be public.

## Solution

**Netlify Function proxy** (`netlify/functions/market-data.js`, routed via `netlify.toml` as `/api/market/*`):
- Allowlists the four endpoints the site uses; strips any client-supplied `api_key`
- Appends `CRYPTOCOMPARE_API_KEY` server-side from the Netlify environment variable (already configured)
- CDN cache headers protect the quota: 5 min for current prices and same-day history; 1 year + `immutable` (durable cache) for closed past UTC days, whose data never changes. Netlify purges its cache on each deploy, so long TTLs can't go stale across releases.

**Client pages** now call the same-origin proxy instead of `min-api.cryptocompare.com` directly. `marketcaps.js` (LiveCoinWatch) is unaffected.

**Secret-leak fix**: `bin/check-api-contracts.js` printed full endpoint URLs including `api_key` into `report.json`/`report.md`, which the workflow uploads as a publicly downloadable artifact. Endpoints and error messages are now redacted (`api_key=REDACTED`). The `CRYPTOCOMPARE_API_KEY` repository secret is set, so the scheduled job goes green once this merges.

## Validation

- Jest: 18 suites, 107 tests pass, coverage thresholds met (new: 9-test suite for the proxy function, key-redaction regression test)
- ESLint: clean
- Live `npm run test:api-contracts` with the key: all 4 checks PASS, saved reports verified key-free
- Page-console smoke (headless Chrome) on all 17 affected pages (4 features × 5 locales): PASS

## Post-merge

- Netlify deploy picks up `netlify.toml` + the function automatically; env var is already set
- Trigger the `Live API Contracts` workflow manually to confirm green

🤖 Generated with [Claude Code](https://claude.com/claude-code)