### PR TITLE
Improve calculator API error handling

### DIFF
--- a/_pages/de/de-calculator.md
+++ b/_pages/de/de-calculator.md
@@ -154,6 +154,10 @@ faq:
                 <span>Dieses Datum ist nicht in unserem Register.</span>
                 <div>Versuchen Sie es beispielsweise mit einem anderen Datum <a class="suggestedDate">2022-05-01</a>.</div>
             </div>
+            <div class="error api-error">
+                <span>Marktpreisdaten sind im Moment nicht verfügbar.</span>
+                <div>Bitte versuchen Sie es in ein paar Minuten erneut.</div>
+            </div>
         </p>
     </div>
 

--- a/_pages/de/de-invest.md
+++ b/_pages/de/de-invest.md
@@ -82,6 +82,7 @@ jquery: true
         <p>
             <span class="error coin-error">Diese Kryptowährung wird von unserem System nicht unterstützt.</span>
             <span class="error date-error">Für dieses Datum sind in unserem Verlauf keine Daten verfügbar.</span>
+            <span class="error api-error">Marktpreisdaten sind im Moment nicht verfügbar. Bitte versuchen Sie es in ein paar Minuten erneut.</span>
         </p>
     </div>
 </div>

--- a/_pages/de/de-simulator.md
+++ b/_pages/de/de-simulator.md
@@ -119,6 +119,10 @@ mailchimp_tracking: false
             <div>Denke daran, den Coin-Code anstelle des vollständigen Namens zu verwenden.</div>
             <div>Zum Beispiel: <a>DOGE</a>, <a>SHIB</a>, <a>DOT</a>, <a>FIL</a>, <a>TRX</a>, <a>BNB</a>...</div>
         </div>
+        <div class="error api-error">
+            <span>Marktpreisdaten sind im Moment nicht verfügbar.</span>
+            <div>Bitte versuchen Sie es in ein paar Minuten erneut.</div>
+        </div>
     </div>
 
     {% include ads_calculator_banner.html %}

--- a/_pages/en/en-calculator.md
+++ b/_pages/en/en-calculator.md
@@ -154,6 +154,10 @@ faq:
                 <span>This date is not in our register.</span>
                 <div>Try another date, for example <a class="suggestedDate">2022-05-01</a>.</div>
             </div>
+            <div class="error api-error">
+                <span>Market price data is unavailable right now.</span>
+                <div>Please try again in a few minutes.</div>
+            </div>
         </p>
     </div>
 

--- a/_pages/en/en-invest.md
+++ b/_pages/en/en-invest.md
@@ -87,6 +87,7 @@ jquery: true
         <p>
             <span class="error coin-error">This cryptocurrency is not covered by our system.</span>
             <span class="error date-error">This date is not included in our register.</span>
+            <span class="error api-error">Market price data is unavailable right now. Please try again in a few minutes.</span>
         </p>
     </div>
 </div>

--- a/_pages/en/en-simulator.md
+++ b/_pages/en/en-simulator.md
@@ -119,6 +119,10 @@ mailchimp_tracking: false
             <div>Remember to try with the coin code instead of the full name.</div>
             <div>For example: <a>DOGE</a>, <a>SHIB</a>, <a>DOT</a>, <a>FIL</a>, <a>TRX</a>, <a>BNB</a>...</div>
         </div>
+        <div class="error api-error">
+            <span>Market price data is unavailable right now.</span>
+            <div>Please try again in a few minutes.</div>
+        </div>
     </div>
 
     {% include ads_calculator_banner.html %}

--- a/_pages/es/calculator.md
+++ b/_pages/es/calculator.md
@@ -152,6 +152,10 @@ faq:
                 <span>Esta fecha no está cubierta en nuestro historial.</span>
                 <div>Prueba con otra fecha, por ejemplo <a class="suggestedDate">2022-05-01</a>.</div>
             </div>
+            <div class="error api-error">
+                <span>Los datos de mercado no están disponibles ahora mismo.</span>
+                <div>Inténtalo de nuevo en unos minutos.</div>
+            </div>
         </p>
 
         

--- a/_pages/es/invest.md
+++ b/_pages/es/invest.md
@@ -83,6 +83,7 @@ jquery: true
         <p>
             <span class="error coin-error">Esta criptomoneda no está cubierta por nuestro sistema.</span>
             <span class="error date-error">Esta fecha no está cubierta en nuestro historial.</span>
+            <span class="error api-error">Los datos de mercado no están disponibles ahora mismo. Inténtalo de nuevo en unos minutos.</span>
         </p>
     </div>
 </div>

--- a/_pages/es/simulator.md
+++ b/_pages/es/simulator.md
@@ -119,6 +119,10 @@ mailchimp_tracking: false
             <div>Recuerda probar con el código de la moneda en lugar del nombre completo.</div>
             <div>Por ejemplo: <a>DOGE</a>, <a>SHIB</a>, <a>DOT</a>, <a>FIL</a>, <a>TRX</a>, <a>BNB</a>...</div>
         </div>
+        <div class="error api-error">
+            <span>Los datos de mercado no están disponibles ahora mismo.</span>
+            <div>Inténtalo de nuevo en unos minutos.</div>
+        </div>
     </div>
 
     {% include ads_calculator_banner.html %}

--- a/_pages/fr/fr-calculator.md
+++ b/_pages/fr/fr-calculator.md
@@ -153,6 +153,10 @@ faq:
                 <span>Cette date n'est pas dans notre registre.</span>
                 <div>Essayez une autre date, par exemple <a class="suggestedDate">2022-05-01</a>.</div>
             </div>
+            <div class="error api-error">
+                <span>Les données de prix du marché ne sont pas disponibles pour le moment.</span>
+                <div>Veuillez réessayer dans quelques minutes.</div>
+            </div>
         </p>
     </div>
 

--- a/_pages/fr/fr-invest.md
+++ b/_pages/fr/fr-invest.md
@@ -82,6 +82,7 @@ jquery: true
         <p>
             <span class="error coin-error">Cette crypto-monnaie n'est pas couverte par notre système.</span>
             <span class="error date-error">Cette date n'est pas incluse dans notre historique.</span>
+            <span class="error api-error">Les données de prix du marché ne sont pas disponibles pour le moment. Veuillez réessayer dans quelques minutes.</span>
         </p>
     </div>
 </div>

--- a/_pages/fr/fr-simulator.md
+++ b/_pages/fr/fr-simulator.md
@@ -119,6 +119,10 @@ mailchimp_tracking: false
             <div>N'oubliez pas d'essayer avec le code de devise au lieu du nom complet.</div>
             <div>Par exemple: <a>DOGE</a>, <a>SHIB</a>, <a>DOT</a>, <a>FIL</a>, <a>TRX</a>, <a>BNB</a>...</div>
         </div>
+        <div class="error api-error">
+            <span>Les données de prix du marché ne sont pas disponibles pour le moment.</span>
+            <div>Veuillez réessayer dans quelques minutes.</div>
+        </div>
     </div>
 
     {% include ads_calculator_banner.html %}

--- a/_pages/pt/pt-calculator.md
+++ b/_pages/pt/pt-calculator.md
@@ -156,6 +156,10 @@ faq:
                 <span>Esta data não está em nosso cadastro.</span>
                 <div>Tente outra data, por exemplo <a class="suggestedDate">2022-05-01</a>.</div>
             </div>
+            <div class="error api-error">
+                <span>Os dados de preço do mercado não estão disponíveis neste momento.</span>
+                <div>Tente novamente em alguns minutos.</div>
+            </div>
         </p>
     </div>
 

--- a/_pages/pt/pt-invest.md
+++ b/_pages/pt/pt-invest.md
@@ -82,6 +82,7 @@ jquery: true
         <p>
             <span class="error coin-error">Esta criptomoeda não está coberta pelo nosso sistema.</span>
             <span class="error date-error">Esta data não está incluída no nosso histórico.</span>
+            <span class="error api-error">Os dados de preço do mercado não estão disponíveis neste momento. Tente novamente em alguns minutos.</span>
         </p>
     </div>
 </div>

--- a/_pages/pt/pt-simulator.md
+++ b/_pages/pt/pt-simulator.md
@@ -119,6 +119,10 @@ mailchimp_tracking: false
             <div>Lembre-se de tentar com o código da moeda em vez do nome completo.</div>
             <div>Por exemplo: <a>DOGE</a>, <a>SHIB</a>, <a>DOT</a>, <a>FIL</a>, <a>TRX</a>, <a>BNB</a>...</div>
         </div>
+        <div class="error api-error">
+            <span>Os dados de preço do mercado não estão disponíveis neste momento.</span>
+            <div>Tente novamente em alguns minutos.</div>
+        </div>
     </div>
 
     {% include ads_calculator_banner.html %}

--- a/_sass/_calculator.scss
+++ b/_sass/_calculator.scss
@@ -379,6 +379,11 @@ p.calculator-affiliate-terms {
     }
 }
 
+.error.api-error.is-visible {
+    display: block;
+    margin-bottom: 20px;
+}
+
 // ============================================================
 // SIMULATOR SPECIFIC
 // ============================================================

--- a/js/calculator-common.js
+++ b/js/calculator-common.js
@@ -48,6 +48,38 @@ function getCurrencyErrorTarget() {
   return investCurrency;
 }
 
+function isProviderApiError(data) {
+  var err = data && data.Err;
+  var statusCode = Number(err && (err.http_status_code || err.status || err.code));
+  var message = String(
+    (err && err.message) ||
+    (data && (data.Message || data.message || data.error)) ||
+    ''
+  ).toLowerCase();
+
+  if (err && (Number.isFinite(statusCode) ? statusCode >= 400 : true)) {
+    return true;
+  }
+
+  return message.indexOf('api key') !== -1 ||
+    message.indexOf('unauthorized') !== -1 ||
+    message.indexOf('forbidden') !== -1 ||
+    message.indexOf('rate limit') !== -1 ||
+    message.indexOf('too many requests') !== -1 ||
+    message.indexOf('temporarily unavailable') !== -1 ||
+    message.indexOf('service unavailable') !== -1;
+}
+
+function getAjaxErrorType(response) {
+  var status = Number(response && response.status);
+
+  if (Number.isFinite(status) && status >= 400) {
+    return 'api';
+  }
+
+  return 'api';
+}
+
 // handle errors and apply red colors
 function handleError(type) {
   clearCalculatorErrors();
@@ -60,6 +92,10 @@ function handleError(type) {
     }
     if (document.querySelector('.coin-error')) {
       document.querySelector('.coin-error').classList.add('is-visible');
+    }
+  } else if (type === 'api') {
+    if (document.querySelector('.api-error')) {
+      document.querySelector('.api-error').classList.add('is-visible');
     }
   } else {
     if (document.querySelector('#invest-date')) {
@@ -74,7 +110,9 @@ function handleError(type) {
       document.querySelector(".suggestedDate").innerHTML = suggestedDate.toISOString().split('T')[0];
     }
   }
-  document.querySelector('#calculator-results').classList.remove('is-visible');
+  if (document.querySelector('#calculator-results')) {
+    document.querySelector('#calculator-results').classList.remove('is-visible');
+  }
   
 }
 
@@ -112,10 +150,12 @@ initCalculatorCommon();
 if (typeof module !== 'undefined') {
   module.exports = {
     clearCalculatorErrors: clearCalculatorErrors,
+    getAjaxErrorType: getAjaxErrorType,
     getCurrencyErrorTarget: getCurrencyErrorTarget,
     handleError: handleError,
     handleInvestCurrencyChange: handleInvestCurrencyChange,
     initCalculatorCommon: initCalculatorCommon,
+    isProviderApiError: isProviderApiError,
     syncEditableCoinInput: syncEditableCoinInput,
     updateInputMinDate: updateInputMinDate
   };

--- a/js/calculator.js
+++ b/js/calculator.js
@@ -64,7 +64,53 @@ function parseCurrentPriceResponse(response, fiat) {
   return currentPrice;
 }
 
+function isCalculatorProviderApiError(data) {
+  if (typeof isProviderApiError === 'function') {
+    return isProviderApiError(data);
+  }
+
+  var err = data && data.Err;
+  var statusCode = Number(err && (err.http_status_code || err.status || err.code));
+  var message = String(
+    (err && err.message) ||
+    (data && (data.Message || data.message || data.error)) ||
+    ''
+  ).toLowerCase();
+
+  if (err && (Number.isFinite(statusCode) ? statusCode >= 400 : true)) {
+    return true;
+  }
+
+  return message.indexOf('api key') !== -1 ||
+    message.indexOf('unauthorized') !== -1 ||
+    message.indexOf('forbidden') !== -1 ||
+    message.indexOf('rate limit') !== -1 ||
+    message.indexOf('too many requests') !== -1 ||
+    message.indexOf('temporarily unavailable') !== -1 ||
+    message.indexOf('service unavailable') !== -1;
+}
+
+function getFetchErrorType(error) {
+  return error && error.calculatorErrorType ? error.calculatorErrorType : 'api';
+}
+
+function parseProviderJson(response) {
+  return response.json().then(function(data) {
+    if (response.ok === false || isCalculatorProviderApiError(data)) {
+      var error = new Error('Provider API error');
+      error.calculatorErrorType = 'api';
+      throw error;
+    }
+
+    return data;
+  });
+}
+
 function parseHistoricalPriceResponse(data, tokenSymbol, fiat) {
+  if (isCalculatorProviderApiError(data)) {
+    return { error: 'api', price: null };
+  }
+
   if (data && data.Response === 'Error') {
     return { error: 'currency', price: null };
   }
@@ -335,7 +381,7 @@ function calculateEarnings() {
     Array.from(document.getElementsByClassName('error')).forEach(el => el.classList.remove('is-visible'));
 
     fetch('https://min-api.cryptocompare.com/data/price?fsym=' + investment.tokenSymbol + '&tsyms=' + investment.fiat)
-      .then(response => response.json())
+      .then(parseProviderJson)
       .then((response) => {
         const currentPrice = parseCurrentPriceResponse(response, investment.fiat);
 
@@ -362,7 +408,7 @@ function calculateEarnings() {
         // } else {
           // altcoin api
           fetch('https://min-api.cryptocompare.com/data/pricehistorical?fsym=' + investment.tokenSymbol + '&tsyms=' + investment.fiat + '&ts=' + timestamp)
-            .then(data => data.json())
+            .then(parseProviderJson)
             .then((data) => {
               const historicalPriceData = parseHistoricalPriceResponse(data, investment.tokenSymbol, investment.fiat);
 
@@ -375,13 +421,13 @@ function calculateEarnings() {
               loading('off');
             })
             .catch(function () {
-              handleError('date');
+              handleError('api');
               loading('off');
             });
         // }
       })
-      .catch(function () {
-        handleError('date');
+      .catch(function (error) {
+        handleError(getFetchErrorType(error));
         loading('off');
       });
   } else {
@@ -504,6 +550,7 @@ if (typeof module !== 'undefined') {
     loadRecommendationArticles: loadRecommendationArticles,
     loadScriptOnce: loadScriptOnce,
     parseCurrentPriceResponse: parseCurrentPriceResponse,
+    parseProviderJson: parseProviderJson,
     parseHistoricalPriceResponse: parseHistoricalPriceResponse,
     preFill: preFill,
     shareOnSocial: shareOnSocial

--- a/js/invest.js
+++ b/js/invest.js
@@ -120,6 +120,40 @@ function parseCurrentPriceResponse(priceData, fiat) {
   return parsedCurrentPrice;
 }
 
+function isInvestProviderApiError(data) {
+  if (typeof isProviderApiError === 'function') {
+    return isProviderApiError(data);
+  }
+
+  var err = data && data.Err;
+  var statusCode = Number(err && (err.http_status_code || err.status || err.code));
+  var message = String(
+    (err && err.message) ||
+    (data && (data.Message || data.message || data.error)) ||
+    ''
+  ).toLowerCase();
+
+  if (err && (Number.isFinite(statusCode) ? statusCode >= 400 : true)) {
+    return true;
+  }
+
+  return message.indexOf('api key') !== -1 ||
+    message.indexOf('unauthorized') !== -1 ||
+    message.indexOf('forbidden') !== -1 ||
+    message.indexOf('rate limit') !== -1 ||
+    message.indexOf('too many requests') !== -1 ||
+    message.indexOf('temporarily unavailable') !== -1 ||
+    message.indexOf('service unavailable') !== -1;
+}
+
+function getInvestAjaxErrorType(response) {
+  if (typeof getAjaxErrorType === 'function') {
+    return getAjaxErrorType(response);
+  }
+
+  return 'api';
+}
+
 function buildCurrentInvestment(latestResult, currentPrice, today) {
   if (!latestResult || !Number.isFinite(currentPrice)) {
     return null;
@@ -217,6 +251,9 @@ function normalizeHistoricalResponse(data) {
 
   if (!data) {
     return { error: 'date', bpi: null };
+  }
+  if (isInvestProviderApiError(data)) {
+    return { error: 'api', bpi: null };
   }
   if (data.Response === 'Error') {
     return { error: getCryptoCompareHistoricalErrorType(data), bpi: null };
@@ -383,7 +420,11 @@ function calculateEarnings() {
           const currentInvestment = buildCurrentInvestment(latestResult, parsedCurrentPrice, investment.today);
 
           if (!currentInvestment) {
-            handleError(priceData && priceData.Response === 'Error' ? 'currency' : 'date');
+            if (isInvestProviderApiError(priceData)) {
+              handleError('api');
+            } else {
+              handleError(priceData && priceData.Response === 'Error' ? 'currency' : 'date');
+            }
             return;
           }
           investmentDataArray.push(currentInvestment);
@@ -407,15 +448,15 @@ function calculateEarnings() {
                         + '&date=' + document.getElementById('invest-date').value + '';
           history.replaceState({}, null, window.location.pathname + newParams);
         })
-        .error(function () {
-          handleError('date');
+        .error(function (response) {
+          handleError(getInvestAjaxErrorType(response));
         })
         .always(function () {
           table.processing( false );
         });
     })
-    .error(function () {
-      handleError('date');
+    .error(function (response) {
+      handleError(getInvestAjaxErrorType(response));
       table.processing( false );
     })
     .always(function () {
@@ -507,9 +548,11 @@ if (typeof module !== 'undefined') {
     getCryptoCompareHistodayLimit: getCryptoCompareHistodayLimit,
     getDateDiffDays: getDateDiffDays,
     getEffectiveInvestMinDate: getEffectiveInvestMinDate,
+    getInvestAjaxErrorType: getInvestAjaxErrorType,
     getSelectedInvestMinDate: getSelectedInvestMinDate,
     initInvestCalculator: initInvestCalculator,
     isValidInterval: isValidInterval,
+    isInvestProviderApiError: isInvestProviderApiError,
     isSupportedPresetSymbol: isSupportedPresetSymbol,
     normalizeCoindeskResponse: normalizeCoindeskResponse,
     normalizeHistoricalResponse: normalizeHistoricalResponse,

--- a/js/simulator.js
+++ b/js/simulator.js
@@ -16,8 +16,54 @@ function formatPercentage(pct) {
   return (pct >= 0 ? '+' : '') + pct.toFixed(2) + '%';
 }
 
-function showSimulatorError() {
-  document.querySelector('.coin-error').classList.add('is-visible');
+function isSimulatorProviderApiError(data) {
+  if (typeof isProviderApiError === 'function') {
+    return isProviderApiError(data);
+  }
+
+  var err = data && data.Err;
+  var statusCode = Number(err && (err.http_status_code || err.status || err.code));
+  var message = String(
+    (err && err.message) ||
+    (data && (data.Message || data.message || data.error)) ||
+    ''
+  ).toLowerCase();
+
+  if (err && (Number.isFinite(statusCode) ? statusCode >= 400 : true)) {
+    return true;
+  }
+
+  return message.indexOf('api key') !== -1 ||
+    message.indexOf('unauthorized') !== -1 ||
+    message.indexOf('forbidden') !== -1 ||
+    message.indexOf('rate limit') !== -1 ||
+    message.indexOf('too many requests') !== -1 ||
+    message.indexOf('temporarily unavailable') !== -1 ||
+    message.indexOf('service unavailable') !== -1;
+}
+
+function parseSimulatorJson(response) {
+  return response.json().then(function(data) {
+    if (response.ok === false || isSimulatorProviderApiError(data)) {
+      var error = new Error('Provider API error');
+      error.calculatorErrorType = 'api';
+      throw error;
+    }
+
+    return data;
+  });
+}
+
+function showSimulatorError(type) {
+  var apiError = document.querySelector('.api-error');
+  var coinError = document.querySelector('.coin-error');
+
+  if (apiError) {
+    apiError.classList.toggle('is-visible', type === 'api');
+  }
+  if (coinError) {
+    coinError.classList.toggle('is-visible', type !== 'api');
+  }
   document.querySelector('#simulator-results').classList.remove('is-visible');
   document.querySelector('.calculator-loader-container').classList.remove('is-visible');
   document.querySelector('.calculator-result-container').classList.add('is-visible');
@@ -25,6 +71,9 @@ function showSimulatorError() {
 
 function hideSimulatorError() {
   document.querySelector('.coin-error').classList.remove('is-visible');
+  if (document.querySelector('.api-error')) {
+    document.querySelector('.api-error').classList.remove('is-visible');
+  }
   if (document.querySelector('.calculator-othercoins')) {
     document.querySelector('.calculator-othercoins').classList.remove('input-error');
   }
@@ -89,9 +138,13 @@ function calculateSimulator() {
 
   fetch(url)
     .then(function(response) {
-      return response.json();
+      return parseSimulatorJson(response);
     })
     .then(function(data) {
+      if (isSimulatorProviderApiError(data)) {
+        showSimulatorError('api');
+        return;
+      }
       if (data && data.Response === 'Error') {
         showSimulatorError();
         return;
@@ -105,7 +158,7 @@ function calculateSimulator() {
       showSimulatorResults();
     })
     .catch(function() {
-      showSimulatorError();
+      showSimulatorError('api');
     });
 }
 
@@ -114,7 +167,9 @@ if (typeof module !== 'undefined') {
     formatCurrency: formatCurrency,
     formatPercentage: formatPercentage,
     getSimulatorCoin: getSimulatorCoin,
+    isSimulatorProviderApiError: isSimulatorProviderApiError,
     paintSimulatorResults: paintSimulatorResults,
+    parseSimulatorJson: parseSimulatorJson,
     showSimulatorLoading: showSimulatorLoading,
     showSimulatorResults: showSimulatorResults,
     showSimulatorError: showSimulatorError,
@@ -122,4 +177,3 @@ if (typeof module !== 'undefined') {
     calculateSimulator: calculateSimulator
   };
 }
-

--- a/tests/calculator-and-invest.test.js
+++ b/tests/calculator-and-invest.test.js
@@ -35,6 +35,16 @@ describe('calculator.js and invest.js', () => {
       error: 'currency',
       price: null
     });
+    expect(calculator.parseHistoricalPriceResponse({
+      Data: {},
+      Err: {
+        message: 'API key required',
+        http_status_code: 401
+      }
+    }, 'BTC', 'USD')).toEqual({
+      error: 'api',
+      price: null
+    });
     expect(calculator.parseHistoricalPriceResponse({ BTC: { USD: '100' } }, 'BTC', 'USD')).toEqual({
       error: null,
       price: 100
@@ -118,6 +128,16 @@ describe('calculator.js and invest.js', () => {
       Message: 'CCCAGG market does not exist for this coin pair (UNKNOWN-USD)'
     })).toEqual({
       error: 'currency',
+      bpi: null
+    });
+    expect(invest.normalizeHistoricalResponse({
+      Data: {},
+      Err: {
+        message: 'API key required',
+        http_status_code: 401
+      }
+    })).toEqual({
+      error: 'api',
       bpi: null
     });
     expect(invest.buildCryptoCompareHistoricalUrl('ETH', 'USD', '2024-01-01', '2024-01-10')).toContain('/data/v2/histoday');
@@ -324,6 +344,29 @@ describe('calculator.js and invest.js', () => {
     invest.calculateEarnings();
 
     expect(global.handleError).toHaveBeenCalledWith('date');
+    expect(table.rows.add).not.toHaveBeenCalled();
+  });
+
+  test('invest.js reports provider API failures separately from date coverage', () => {
+    buildInvestDom();
+    const table = createDataTableStub();
+    setupJQuery(table);
+    setupGetQueue([
+      {
+        response: {
+          Data: {},
+          Err: {
+            message: 'API key required',
+            http_status_code: 401
+          }
+        }
+      }
+    ]);
+
+    const invest = loadModule('../js/invest.js');
+    invest.calculateEarnings();
+
+    expect(global.handleError).toHaveBeenCalledWith('api');
     expect(table.rows.add).not.toHaveBeenCalled();
   });
 

--- a/tests/calculator-common.test.js
+++ b/tests/calculator-common.test.js
@@ -13,6 +13,7 @@ describe('calculator-common.js', () => {
       <input id="invest-date" min="" value="2019-01-01" />
       <div class="coin-error error" style="display:none"></div>
       <div class="date-error error" style="display:none"><span class="suggestedDate"></span></div>
+      <div class="api-error error" style="display:none"></div>
       <div id="calculator-results" style="display:block"></div>
     `;
   });
@@ -51,6 +52,26 @@ describe('calculator-common.js', () => {
     expect(document.querySelector('.suggestedDate').textContent).toMatch(/\d{4}-\d{2}-\d{2}/);
   });
 
+  test('shows provider API errors without marking user inputs invalid', () => {
+    const calculatorCommon = loadModule('../js/calculator-common.js');
+
+    expect(calculatorCommon.isProviderApiError({
+      Data: {},
+      Err: {
+        message: 'API key required',
+        http_status_code: 401
+      }
+    })).toBe(true);
+
+    calculatorCommon.handleError('api');
+
+    expect(document.querySelector('.api-error').classList.contains('is-visible')).toBe(true);
+    expect(document.querySelector('.coin-error').classList.contains('is-visible')).toBe(false);
+    expect(document.querySelector('.date-error').classList.contains('is-visible')).toBe(false);
+    expect(document.querySelector('#invest-date').classList.contains('input-error')).toBe(false);
+    expect(document.querySelector('#invest-currency').classList.contains('input-error')).toBe(false);
+  });
+
   test('highlights the editable coin input for custom currency errors', () => {
     const calculatorCommon = loadModule('../js/calculator-common.js');
     const select = document.querySelector('#invest-currency');
@@ -82,4 +103,3 @@ describe('calculator-common.js', () => {
     expect(document.querySelector('#invest-date').value).toBe('2021-03-01');
   });
 });
-

--- a/tests/calculator-coverage.test.js
+++ b/tests/calculator-coverage.test.js
@@ -88,6 +88,47 @@ describe('calculator.js extra coverage', () => {
     expect(global.handleError).toHaveBeenCalledWith('currency');
   });
 
+  test('shows api error when provider returns auth/API failure payloads', async () => {
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce({ json: jest.fn().mockResolvedValue({ USD: 200 }) })
+      .mockResolvedValueOnce({ json: jest.fn().mockResolvedValue({
+        Data: {},
+        Err: {
+          message: 'API key required',
+          http_status_code: 401
+        }
+      }) });
+
+    const calculator = loadModule('../js/calculator.js');
+    calculator.calculateEarnings();
+    await flushPromises();
+    await flushPromises();
+    await flushPromises();
+
+    expect(global.handleError).toHaveBeenCalledWith('api');
+  });
+
+  test('shows api error when provider responds with a failing HTTP status', async () => {
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        json: jest.fn().mockResolvedValue({
+          Data: {},
+          Err: {
+            message: 'API key required',
+            http_status_code: 401
+          }
+        })
+      });
+
+    const calculator = loadModule('../js/calculator.js');
+    calculator.calculateEarnings();
+    await flushPromises();
+    await flushPromises();
+
+    expect(global.handleError).toHaveBeenCalledWith('api');
+  });
+
   test('marks negative returns and malformed current-price responses as errors', async () => {
     global.fetch = jest.fn()
       .mockResolvedValueOnce({ json: jest.fn().mockResolvedValue({ USD: 100 }) })
@@ -275,4 +316,3 @@ describe('calculator.js extra coverage', () => {
     await expect(failingRecommendationPromise).resolves.toBe(false);
   });
 });
-

--- a/tests/helpers/page-builders.js
+++ b/tests/helpers/page-builders.js
@@ -37,6 +37,7 @@ function buildCalculatorDom() {
     <div class="gained-percentage"></div>
     <div class="error coin-error"><a>ETH</a></div>
     <div class="error date-error"><a>2024-02-02</a></div>
+    <div class="error api-error"></div>
     <input class="calculator-othercoins" />
     <div class="calculator-othercoins"></div>
     <input class="editable" />
@@ -76,6 +77,7 @@ function buildInvestDom() {
     <span id="result-currentvalue"></span>
     <div class="error coin-error" style="display:none"></div>
     <div class="error date-error" style="display:none"></div>
+    <div class="error api-error" style="display:none"></div>
   `;
   global.tableDataLang = {
     general: {},

--- a/tests/provider-branches.test.js
+++ b/tests/provider-branches.test.js
@@ -65,7 +65,7 @@ describe('provider edge branches', () => {
     let invest = loadModule('../js/invest.js');
     invest.calculateEarnings();
 
-    expect(global.handleError).toHaveBeenCalledWith('date');
+    expect(global.handleError).toHaveBeenCalledWith('api');
     expect(table.processing).toHaveBeenLastCalledWith(false);
     expect(table.rows.add).not.toHaveBeenCalled();
 
@@ -92,7 +92,7 @@ describe('provider edge branches', () => {
     invest = loadModule('../js/invest.js');
     invest.calculateEarnings();
 
-    expect(global.handleError).toHaveBeenCalledWith('date');
+    expect(global.handleError).toHaveBeenCalledWith('api');
     expect(table.rows.add).not.toHaveBeenCalled();
   });
 

--- a/tests/simulator.test.js
+++ b/tests/simulator.test.js
@@ -36,6 +36,7 @@ function buildSimulatorDom() {
         </table>
       </div>
       <div class="error coin-error"></div>
+      <div class="error api-error"></div>
     </div>
   `;
 }
@@ -272,6 +273,25 @@ describe('simulator.js', () => {
       expect(document.querySelector('#simulator-results').classList.contains('is-visible')).toBe(false);
     });
 
+    test('shows api-error when API returns an auth/provider error payload', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        json: jest.fn().mockResolvedValue({
+          Data: {},
+          Err: {
+            message: 'API key required',
+            http_status_code: 401
+          }
+        })
+      });
+      const sim = loadModule('../js/simulator.js');
+      sim.calculateSimulator();
+      await flushPromises();
+      await flushPromises();
+      expect(document.querySelector('.api-error').classList.contains('is-visible')).toBe(true);
+      expect(document.querySelector('.coin-error').classList.contains('is-visible')).toBe(false);
+      expect(document.querySelector('#simulator-results').classList.contains('is-visible')).toBe(false);
+    });
+
     test('shows error when API returns a price of zero', async () => {
       global.fetch = jest.fn().mockResolvedValue({
         json: jest.fn().mockResolvedValue({ USD: 0 })
@@ -289,7 +309,8 @@ describe('simulator.js', () => {
       sim.calculateSimulator();
       await flushPromises();
       await flushPromises();
-      expect(document.querySelector('.coin-error').classList.contains('is-visible')).toBe(true);
+      expect(document.querySelector('.api-error').classList.contains('is-visible')).toBe(true);
+      expect(document.querySelector('.coin-error').classList.contains('is-visible')).toBe(false);
     });
 
     test('paints results and shows simulator-results on a successful API response', async () => {


### PR DESCRIPTION
Separates provider/API failures from date and currency validation in the simple, DCA, and simulator calculators.
Adds localized API outage messages across es/en/de/fr/pt and spacing so the message does not overlap DataTables controls.
Root cause: CryptoCompare can return 401/API-key payloads before historical coverage can be determined, and those were shown as missing date history.
Validation: npm test, npm run eslint, npm run build; npm run test:api-contracts still reproduces CryptoCompare 401 while LiveCoinWatch passes, and page-console smoke is blocked locally by missing Chrome/Edge.