### PR TITLE
[codex] Improve Conductor archive cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+.DS_Store
 _site
 .sass-cache
 .jekyll-metadata

--- a/bin/conductor-archive-cleanup.sh
+++ b/bin/conductor-archive-cleanup.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -u
+
+export PATH="/opt/homebrew/opt/ruby/bin:/usr/local/opt/ruby/bin:$PATH"
+export BUNDLE_FROZEN=true
+
+workspace_path="${CONDUCTOR_WORKSPACE_PATH:-$PWD}"
+cd "$workspace_path" || exit 1
+
+git_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ "$git_root" != "$PWD" ]; then
+  echo "Refusing to archive-clean from outside the workspace root: $PWD" >&2
+  exit 1
+fi
+
+if [ ! -f Gemfile ] || [ ! -f package.json ]; then
+  echo "Refusing to archive-clean: expected Gemfile and package.json in $PWD" >&2
+  exit 1
+fi
+
+bundle exec jekyll clean || true
+
+rm -rf \
+  .bundle \
+  .cache \
+  .context \
+  .jekyll-cache \
+  .jekyll-metadata \
+  .sass-cache \
+  artifacts \
+  coverage \
+  node_modules \
+  vendor/bundle \
+  _site

--- a/conductor.json
+++ b/conductor.json
@@ -2,7 +2,7 @@
   "scripts": {
     "setup": "export PATH=\"/opt/homebrew/opt/ruby/bin:/usr/local/opt/ruby/bin:$PATH\"; ruby -e 'abort(\"Ruby 3.2+ required; install Ruby 3.x first, for example with: brew install ruby\") unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new(\"3.2.0\")' && BUNDLER_VERSION=$(awk '/^BUNDLED WITH$/{getline; gsub(/^[[:space:]]+/, \"\"); print; exit}' Gemfile.lock) && (gem list -i bundler -v \"$BUNDLER_VERSION\" >/dev/null || gem install bundler -v \"$BUNDLER_VERSION\") && npm ci",
     "run": "export PATH=\"/opt/homebrew/opt/ruby/bin:/usr/local/opt/ruby/bin:$PATH\"; export BUNDLE_FROZEN=true; ruby -e 'abort(\"Ruby 3.2+ required; install Ruby 3.x first, for example with: brew install ruby\") unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new(\"3.2.0\")' && bundle exec ruby bin/jekyll-local.rb serve --incremental --host 127.0.0.1 --port ${CONDUCTOR_PORT:-4000}",
-    "archive": "export PATH=\"/opt/homebrew/opt/ruby/bin:/usr/local/opt/ruby/bin:$PATH\"; export BUNDLE_FROZEN=true; bundle exec jekyll clean || true"
+    "archive": "bash bin/conductor-archive-cleanup.sh"
   },
   "runScriptMode": "concurrent"
 }


### PR DESCRIPTION
Adds a dedicated Conductor archive cleanup script and points `conductor.json` at it.

The script removes workspace-local generated files, caches, dependency installs, coverage/artifact output, and `.context` so archived worktrees leave no project disk footprint. It also keeps guardrails around the cleanup path by requiring the workspace git root plus the expected Jekyll/Node project files.

Validation: ran `bash -n bin/conductor-archive-cleanup.sh`.