### PR TITLE
fix: date error (not API error) when no provider has data for the chosen date

### DIFF
--- a/js/calculator.js
+++ b/js/calculator.js
@@ -144,10 +144,19 @@ function fetchCalculatorHistoricalPrice(coin, fiat, dateStr, timestamp) {
       return { error: null, price: price };
     })
     .catch(function (lcwError) {
-      return cryptoComparePath().catch(function (ccError) {
-        // LiveCoinWatch answered "no data for that date" and CryptoCompare
-        // could not answer at all — that is a date problem, not an API one.
-        if (lcwError && lcwError.liveCoinWatchNoData) {
+      var lcwSaidNoData = Boolean(lcwError && lcwError.liveCoinWatchNoData);
+
+      return cryptoComparePath().then(function (result) {
+        // CryptoCompare resolving with an 'api' classification (e.g. its
+        // over-quota HTTP-200 error payload) means it could not actually
+        // answer either — LiveCoinWatch's authoritative "no data for that
+        // date" wins, so the user sees a date problem, not an API one.
+        if (result && result.error === 'api' && lcwSaidNoData) {
+          return { error: 'date', price: null };
+        }
+        return result;
+      }, function (ccError) {
+        if (lcwSaidNoData) {
           return { error: 'date', price: null };
         }
         throw ccError;

--- a/js/invest.js
+++ b/js/invest.js
@@ -206,12 +206,20 @@ function fetchInvestHistoricalBpi(tokenSymbol, fiat, startDate, endDate, selecte
         return { error: null, bpi: bpi };
       })
       .catch(function (lcwError) {
+        var lcwSaidNoData = Boolean(lcwError && lcwError.liveCoinWatchNoData);
+
         return fetchCryptoCompareInvestBpi(tokenSymbol, fiat, startDate, endDate)
-          .catch(function (ccError) {
-            // LiveCoinWatch answered "no data for that range" and
-            // CryptoCompare could not answer at all — report it as a date
-            // problem, not an API one.
-            if (lcwError && lcwError.liveCoinWatchNoData) {
+          .then(function (result) {
+            // CryptoCompare resolving with an 'api' classification (e.g.
+            // its over-quota HTTP-200 error payload) means it could not
+            // actually answer either — LiveCoinWatch's authoritative
+            // "no data for that range" wins: date problem, not API.
+            if (result && result.error === 'api' && lcwSaidNoData) {
+              return { error: 'date', bpi: null };
+            }
+            return result;
+          }, function (ccError) {
+            if (lcwSaidNoData) {
               return { error: 'date', bpi: null };
             }
             throw ccError;

--- a/tests/calculator-and-invest.test.js
+++ b/tests/calculator-and-invest.test.js
@@ -281,6 +281,57 @@ describe('calculator.js and invest.js', () => {
     expect(table.rows.add).not.toHaveBeenCalled();
   });
 
+  test('calculator.js reports a date error when LCW has no data and CryptoCompare is over quota', async () => {
+    buildCalculatorDom();
+    const noData = new Error('LiveCoinWatch history is empty');
+    noData.liveCoinWatchNoData = true;
+    global.fetchLiveCoinWatchHistory = jest.fn().mockRejectedValue(noData);
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce({ json: jest.fn().mockResolvedValue({ USD: 200 }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          Response: 'Error',
+          Message: 'You are over your rate limit please upgrade your account!',
+          Data: {}
+        })
+      });
+
+    const calculator = loadModule('../js/calculator.js');
+    calculator.calculateEarnings();
+    await flushPromises();
+    await flushPromises();
+    await flushPromises();
+
+    expect(global.handleError).toHaveBeenCalledWith('date');
+    expect(global.handleError).not.toHaveBeenCalledWith('api');
+  });
+
+  test('invest.js reports a date error when LCW lacks the start date and CryptoCompare is over quota', async () => {
+    buildInvestDom();
+    const table = createDataTableStub();
+    setupJQuery(table);
+    setupGetQueue([
+      {
+        response: {
+          Response: 'Error',
+          Message: 'You are over your rate limit please upgrade your account!',
+          Data: {}
+        }
+      }
+    ]);
+    global.fetchLiveCoinWatchHistory = jest.fn().mockResolvedValue({ '2021-02-03': 0.00001 });
+    global.fetchCurrentPriceData = jest.fn().mockResolvedValue({ USD: 300 });
+
+    const invest = loadModule('../js/invest.js');
+    invest.calculateEarnings();
+    await flushPromises();
+
+    expect(global.handleError).toHaveBeenCalledWith('date');
+    expect(global.handleError).not.toHaveBeenCalledWith('api');
+    expect(table.rows.add).not.toHaveBeenCalled();
+  });
+
   test('calculator.js serves rate-limited responses that still contain valid data', async () => {
     buildCalculatorDom();
     const softServeWarning = 'You are over your rate limit please upgrade your account!';


### PR DESCRIPTION
## Summary

Follow-up to #100, from production testing: picking a date before a coin's data coverage (AVAX@2014, or SHIB before its LiveCoinWatch coverage start of 2021-02-03) showed the **"connection error"** banner instead of flagging the **date input**.

Root cause: the no-data→date-error downgrade only handled the CryptoCompare fallback *rejecting* (transport failure). With CryptoCompare over quota, the fallback *resolves* with its HTTP-200 rate-limit payload, which classifies as an `api` error and masked LiveCoinWatch's authoritative "no data for that date" answer.

The downgrade now also applies when the fallback resolves with an `api` classification. Genuine CryptoCompare answers (a price, or a `currency`/`date` classification) still take precedence.

## Verification

- 2 regression tests written red-first reproducing the exact production payloads (calculator + DCA); 153/153 passing, ESLint and build clean
- Browser-verified against real APIs: AVAX@2014 in `/calculadora/` and SHIB@2020-12-19 in `/inversion/` now flag the date input with the suggested-date hint; SHIB@2021-06-01 happy path unaffected (63 rows)

## Note on the reported proxy request

`GET /api/market/lcw/history?code=SHIB&...start=1607040000000...` does **not** fail — it returns 200 with 60 points (the chunk is partially covered; SHIB data starts 2021-02-03). The visible failure was purely the error misclassification fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)