### PR TITLE
Strengthen live API contract checks

### DIFF
--- a/bin/check-api-contracts.js
+++ b/bin/check-api-contracts.js
@@ -3,7 +3,17 @@ const path = require('path');
 
 const DEFAULT_REPORT_DIR = path.join(process.cwd(), 'artifacts', 'api-contracts');
 const LEGACY_LIVECOINWATCH_URL = 'https://http-api.livecoinwatch.com/coins?offset=0&limit=1&sort=rank&order=ascending&currency=USD';
-const LIVECOINWATCH_PRICE_LIST_URL = 'https://http-api.livecoinwatch.com/coins?offset=0&limit=200&sort=rank&order=ascending&currency=USD';
+const LIVECOINWATCH_PRICE_LIST_LIMIT = 200;
+const LIVECOINWATCH_PRICE_LIST_MIN_DEPTH = 150;
+const LIVECOINWATCH_PRICE_LIST_CURRENCIES = ['USD', 'EUR'];
+const LIVECOINWATCH_PRESET_CODES = ['BTC', 'ETH', 'LTC', 'IOTA', 'XMR', 'ADA', 'XRP'];
+
+function buildLiveCoinWatchPriceListUrl(currency) {
+  return 'https://http-api.livecoinwatch.com/coins?offset=0&limit='
+    + LIVECOINWATCH_PRICE_LIST_LIMIT
+    + '&sort=rank&order=ascending&currency='
+    + encodeURIComponent(currency);
+}
 
 function addDays(date, days) {
   const result = new Date(date.valueOf());
@@ -66,6 +76,16 @@ function requireFiniteNumber(value, label, endpoint) {
 
   if (!Number.isFinite(parsedValue)) {
     throw createCheckError(label + ' is missing or not numeric.', { endpoint: endpoint });
+  }
+
+  return parsedValue;
+}
+
+function requirePositiveNumber(value, label, endpoint) {
+  const parsedValue = requireFiniteNumber(value, label, endpoint);
+
+  if (parsedValue <= 0) {
+    throw createCheckError(label + ' must be positive.', { endpoint: endpoint });
   }
 
   return parsedValue;
@@ -157,8 +177,27 @@ function createLiveCoinWatchHistoryCheck(now) {
         });
       }
 
-      requireFiniteNumber(points[0] && points[0].date, 'history[0].date', endpoint);
-      requireFiniteNumber(points[0] && points[0].rate, 'history[0].rate', endpoint);
+      let previousDate = null;
+      points.forEach(function (point, index) {
+        const pointDate = requireFiniteNumber(point && point.date, 'history[' + index + '].date', endpoint);
+        requirePositiveNumber(point && point.rate, 'history[' + index + '].rate', endpoint);
+
+        if (pointDate < startMs || pointDate > endMs) {
+          throw createCheckError('history[' + index + '].date is outside the requested range.', {
+            endpoint: endpoint,
+            httpStatus: response.httpStatus
+          });
+        }
+
+        if (previousDate !== null && pointDate <= previousDate) {
+          throw createCheckError('History dates must be strictly increasing.', {
+            endpoint: endpoint,
+            httpStatus: response.httpStatus
+          });
+        }
+
+        previousDate = pointDate;
+      });
 
       return {
         durationMs: response.durationMs,
@@ -176,6 +215,54 @@ function createLiveCoinWatchHistoryCheck(now) {
 // fallback. Set API_CONTRACT_INCLUDE_CRYPTOCOMPARE=1 to check it manually.
 function shouldCheckCryptoCompare() {
   return process.env.API_CONTRACT_INCLUDE_CRYPTOCOMPARE === '1';
+}
+
+function createLiveCoinWatchPriceListCheck(currency) {
+  return {
+    name: 'LiveCoinWatch price list depth (' + currency + ')',
+    provider: 'LiveCoinWatch',
+    run: async function () {
+      const endpoint = buildLiveCoinWatchPriceListUrl(currency);
+      const response = await requestJson('LiveCoinWatch price list depth (' + currency + ')', { url: endpoint });
+      const coins = response.data && response.data.data;
+
+      if (!Array.isArray(coins) || coins.length < LIVECOINWATCH_PRICE_LIST_MIN_DEPTH) {
+        const received = Array.isArray(coins) ? coins.length : 'no';
+        throw createCheckError('Price list returned ' + received + ' coins; calculators expect the top ' + LIVECOINWATCH_PRICE_LIST_LIMIT + '.', {
+          endpoint: endpoint,
+          httpStatus: response.httpStatus
+        });
+      }
+
+      const missingCodes = [];
+      LIVECOINWATCH_PRESET_CODES.forEach(function (code) {
+        const coin = coins.find(function (candidate) {
+          return candidate && candidate.code === code;
+        });
+
+        if (!coin) {
+          missingCodes.push(code);
+          return;
+        }
+
+        requirePositiveNumber(coin.price, code + ' price', endpoint);
+      });
+
+      if (missingCodes.length) {
+        throw createCheckError('Preset coins missing from the top-' + LIVECOINWATCH_PRICE_LIST_LIMIT + ' list: ' + missingCodes.join(', ') + '.', {
+          endpoint: endpoint,
+          httpStatus: response.httpStatus
+        });
+      }
+
+      return {
+        durationMs: response.durationMs,
+        endpoint: endpoint,
+        httpStatus: response.httpStatus,
+        notes: 'Top-' + coins.length + ' ' + currency + ' price list includes all preset coins with positive prices.'
+      };
+    }
+  };
 }
 
 function createContractChecks(now) {
@@ -311,42 +398,7 @@ function createContractChecks(now) {
         };
       }
     },
-    {
-      name: 'LiveCoinWatch price list depth',
-      provider: 'LiveCoinWatch',
-      run: async function () {
-        const endpoint = LIVECOINWATCH_PRICE_LIST_URL;
-        const response = await requestJson('LiveCoinWatch price list depth', { url: endpoint });
-        const coins = response.data && response.data.data;
-
-        if (!Array.isArray(coins) || coins.length < 150) {
-          const received = Array.isArray(coins) ? coins.length : 'no';
-          throw createCheckError('Price list returned ' + received + ' coins; calculators expect the top 200.', {
-            endpoint: endpoint,
-            httpStatus: response.httpStatus
-          });
-        }
-
-        requireFiniteNumber(coins[0] && coins[0].price, 'data[0].price', endpoint);
-
-        const iota = coins.find(function (coin) { return coin && coin.code === 'IOTA'; });
-        if (!iota) {
-          throw createCheckError('IOTA is missing from the top-200 list; the MIOTA preset depends on it.', {
-            endpoint: endpoint,
-            httpStatus: response.httpStatus
-          });
-        }
-        requireFiniteNumber(iota.price, 'IOTA price', endpoint);
-
-        return {
-          durationMs: response.durationMs,
-          endpoint: endpoint,
-          httpStatus: response.httpStatus,
-          notes: 'Top-' + coins.length + ' price list includes IOTA with a numeric price.'
-        };
-      }
-    }
-  ];
+  ].concat(LIVECOINWATCH_PRICE_LIST_CURRENCIES.map(createLiveCoinWatchPriceListCheck));
 
   // The official-API check needs the key, so it only runs where the
   // LIVECOINWATCH_API_KEY secret is configured. In CI a missing key must be

--- a/docs/market-data-apis.md
+++ b/docs/market-data-apis.md
@@ -135,11 +135,12 @@ everywhere, EUR on some pages).
   `calculator-common.js` translates; add new aliases there if presets change.
 - It could disappear without notice, like CoinDesk's free tier did. The daily
   contract job watches both the marketcaps shape (`limit=1`) and the calculators'
-  price list (`limit=200`, depth ≥150, IOTA present). If LiveCoinWatch dies, the
-  calculators silently degrade to CryptoCompare fallback — which the 100/month quota
-  cannot sustain, so treat a red LiveCoinWatch contract check as urgent. The official
-  LiveCoinWatch API (`api.livecoinwatch.com`) requires a key (free tier: 10k
-  credits/day) and is POST-based — it would need a proxy like the CryptoCompare one.
+  USD/EUR price lists (`limit=200`, depth ≥150, all preset coins present). If
+  LiveCoinWatch dies, the calculators silently degrade to CryptoCompare fallback —
+  which the 100/month quota cannot sustain, so treat a red LiveCoinWatch contract
+  check as urgent. The official LiveCoinWatch API (`api.livecoinwatch.com`) requires
+  a key (free tier: 10k credits/day) and is POST-based — it would need a proxy like
+  the CryptoCompare one.
 
 ## Monitoring
 
@@ -147,7 +148,8 @@ everywhere, EUR on some pages).
   06:17 UTC and on manual dispatch. It checks the real provider responses against the
   shapes the site depends on. A red run = provider drift — investigate before users
   notice. Scheduled runs check **LiveCoinWatch only**: the legacy market list,
-  the top-200 price list, and the keyed official-history check (the last only
+  the top-200 USD and EUR price lists for all preset coins (`BTC`, `ETH`, `LTC`,
+  `IOTA`, `XMR`, `ADA`, `XRP`), and the keyed official-history check (the last only
   where `LIVECOINWATCH_API_KEY` is set). The three CryptoCompare fallback checks
   are **off by default** — scheduled runs would spend the fallback's
   100-calls/month quota on watching the fallback. Run them on demand via the

--- a/tests/api-contracts-script.test.js
+++ b/tests/api-contracts-script.test.js
@@ -11,9 +11,19 @@ function createJsonResponse(payload, status) {
 }
 
 function buildPriceListPayload() {
+  const presetCodesByRank = {
+    0: 'BTC',
+    1: 'ETH',
+    19: 'LTC',
+    39: 'XMR',
+    59: 'ADA',
+    79: 'XRP',
+    115: 'IOTA'
+  };
   const coins = [];
   for (let i = 0; i < 200; i++) {
-    coins.push({ code: i === 115 ? 'IOTA' : 'COIN' + i, price: i === 115 ? 0.5 : 10 + i, rank: i + 1 });
+    const code = presetCodesByRank[i] || 'COIN' + i;
+    coins.push({ code: code, price: code === 'IOTA' ? 0.5 : 10 + i, rank: i + 1 });
   }
   return { data: coins };
 }
@@ -57,14 +67,15 @@ describe('live api contract runner', () => {
           rank: 1
         }]
       }))
+      .mockResolvedValueOnce(createJsonResponse(buildPriceListPayload()))
       .mockResolvedValueOnce(createJsonResponse(buildPriceListPayload()));
 
     const report = await apiContracts.runContractChecks({ now: new Date('2026-03-09T12:00:00.000Z') });
 
     expect(report.success).toBe(true);
-    expect(report.results).toHaveLength(5);
+    expect(report.results).toHaveLength(6);
     expect(report.results.every((result) => result.status === 'passed')).toBe(true);
-    expect(global.fetch).toHaveBeenCalledTimes(5);
+    expect(global.fetch).toHaveBeenCalledTimes(6);
     expect(apiContracts.formatMarkdownReport(report)).toContain('Overall: PASS');
   });
 
@@ -80,12 +91,13 @@ describe('live api contract runner', () => {
           rank: 1
         }]
       }))
+      .mockResolvedValueOnce(createJsonResponse(buildPriceListPayload()))
       .mockResolvedValueOnce(createJsonResponse(buildPriceListPayload()));
 
     const report = await apiContracts.runContractChecks({ now: new Date('2026-03-09T12:00:00.000Z') });
 
     expect(report.success).toBe(true);
-    expect(report.results).toHaveLength(2);
+    expect(report.results).toHaveLength(3);
     expect(report.results.every((result) => result.provider === 'LiveCoinWatch')).toBe(true);
 
     process.env.API_CONTRACT_INCLUDE_CRYPTOCOMPARE = '1';
@@ -95,16 +107,18 @@ describe('live api contract runner', () => {
       .mockResolvedValueOnce(createJsonResponse({ BTC: { USD: 48000 } }))
       .mockResolvedValueOnce(createJsonResponse({ Data: { Data: [{ time: 1741478400, close: 101000 }] } }))
       .mockResolvedValueOnce(createJsonResponse({ data: [{ cap: 1, circulating: 1, code: 'BTC', name: 'Bitcoin', price: 1, rank: 1 }] }))
+      .mockResolvedValueOnce(createJsonResponse(buildPriceListPayload()))
       .mockResolvedValueOnce(createJsonResponse(buildPriceListPayload()));
 
     const forcedReport = await apiContracts.runContractChecks({ now: new Date('2026-03-09T12:00:00.000Z') });
-    expect(forcedReport.results).toHaveLength(5);
+    expect(forcedReport.results).toHaveLength(6);
   });
 
   test('fails the keyed history check in CI when the key secret is missing', async () => {
     process.env.GITHUB_ACTIONS = 'true';
     global.fetch
       .mockResolvedValueOnce(createJsonResponse({ data: [{ cap: 1, circulating: 1, code: 'BTC', name: 'Bitcoin', price: 1, rank: 1 }] }))
+      .mockResolvedValueOnce(createJsonResponse(buildPriceListPayload()))
       .mockResolvedValueOnce(createJsonResponse(buildPriceListPayload()));
 
     const report = await apiContracts.runContractChecks({ now: new Date('2026-03-09T12:00:00.000Z') });
@@ -119,8 +133,9 @@ describe('live api contract runner', () => {
     process.env.API_CONTRACT_INCLUDE_CRYPTOCOMPARE = '1';
     process.env.LIVECOINWATCH_API_KEY = 'lcw-test-key';
     const dailyPoints = [];
+    const firstHistoryPoint = Date.UTC(2025, 10, 29);
     for (let i = 0; i < 100; i++) {
-      dailyPoints.push({ date: 1700000000000 + i * 86400000, rate: 30000 + i });
+      dailyPoints.push({ date: firstHistoryPoint + i * 86400000, rate: 30000 + i });
     }
 
     global.fetch
@@ -129,21 +144,22 @@ describe('live api contract runner', () => {
       .mockResolvedValueOnce(createJsonResponse({ Data: { Data: [{ time: 1741478400, close: 101000 }] } }))
       .mockResolvedValueOnce(createJsonResponse({ data: [{ cap: 1, circulating: 1, code: 'BTC', name: 'Bitcoin', price: 1, rank: 1 }] }))
       .mockResolvedValueOnce(createJsonResponse(buildPriceListPayload()))
+      .mockResolvedValueOnce(createJsonResponse(buildPriceListPayload()))
       .mockResolvedValueOnce(createJsonResponse({ history: dailyPoints }));
 
     const report = await apiContracts.runContractChecks({ now: new Date('2026-03-09T12:00:00.000Z') });
     const historyResult = report.results.find((result) => result.name === 'LiveCoinWatch official history (keyed)');
 
-    expect(report.results).toHaveLength(6);
+    expect(report.results).toHaveLength(7);
     expect(historyResult.status).toBe('passed');
-    const [historyUrl, historyOptions] = global.fetch.mock.calls[5];
+    const [historyUrl, historyOptions] = global.fetch.mock.calls[6];
     expect(historyUrl).toBe('https://api.livecoinwatch.com/coins/single/history');
     expect(historyOptions.method).toBe('POST');
     expect(historyOptions.headers['x-api-key']).toBe('lcw-test-key');
     expect(JSON.stringify(report)).not.toContain('lcw-test-key');
   });
 
-  test('fails when the LiveCoinWatch price list is too shallow or missing IOTA', async () => {
+  test('fails when a LiveCoinWatch price list is too shallow or missing preset coins', async () => {
     process.env.API_CONTRACT_INCLUDE_CRYPTOCOMPARE = '1';
     const shallowList = { data: [{ code: 'BTC', price: 60000, rank: 1 }] };
     const noIotaList = buildPriceListPayload();
@@ -157,7 +173,7 @@ describe('live api contract runner', () => {
       .mockResolvedValueOnce(createJsonResponse(shallowList));
 
     const shallowReport = await apiContracts.runContractChecks({ now: new Date('2026-03-09T12:00:00.000Z') });
-    const shallowResult = shallowReport.results.find((result) => result.name === 'LiveCoinWatch price list depth');
+    const shallowResult = shallowReport.results.find((result) => result.name === 'LiveCoinWatch price list depth (USD)');
 
     expect(shallowResult.status).toBe('failed');
     expect(shallowResult.error).toContain('top 200');
@@ -168,10 +184,11 @@ describe('live api contract runner', () => {
       .mockResolvedValueOnce(createJsonResponse({ BTC: { USD: 48000 } }))
       .mockResolvedValueOnce(createJsonResponse({ Data: { Data: [{ time: 1741478400, close: 101000 }] } }))
       .mockResolvedValueOnce(createJsonResponse({ data: [{ cap: 1, circulating: 1, code: 'BTC', name: 'Bitcoin', price: 1, rank: 1 }] }))
+      .mockResolvedValueOnce(createJsonResponse(noIotaList))
       .mockResolvedValueOnce(createJsonResponse(noIotaList));
 
     const noIotaReport = await apiContracts.runContractChecks({ now: new Date('2026-03-09T12:00:00.000Z') });
-    const noIotaResult = noIotaReport.results.find((result) => result.name === 'LiveCoinWatch price list depth');
+    const noIotaResult = noIotaReport.results.find((result) => result.name === 'LiveCoinWatch price list depth (USD)');
 
     expect(noIotaResult.status).toBe('failed');
     expect(noIotaResult.error).toContain('IOTA');
@@ -184,6 +201,7 @@ describe('live api contract runner', () => {
       .mockResolvedValueOnce(createJsonResponse({ BTC: { USD: 48000 } }))
       .mockResolvedValueOnce(createJsonResponse({ Data: { Data: [{ time: 1741478400, close: 101000 }] } }))
       .mockResolvedValueOnce(createJsonResponse({ data: [{}] }))
+      .mockResolvedValueOnce(createJsonResponse(buildPriceListPayload()))
       .mockResolvedValueOnce(createJsonResponse(buildPriceListPayload()));
 
     const report = await apiContracts.runContractChecks({ now: new Date('2026-03-09T12:00:00.000Z') });
@@ -217,6 +235,7 @@ describe('live api contract runner', () => {
           rank: 1
         }]
       }))
+      .mockResolvedValueOnce(createJsonResponse(buildPriceListPayload()))
       .mockResolvedValueOnce(createJsonResponse(buildPriceListPayload()));
 
     const report = await apiContracts.runContractChecks({ now: new Date('2026-03-09T12:00:00.000Z') });
@@ -255,6 +274,7 @@ describe('live api contract runner', () => {
           rank: 1
         }]
       }))
+      .mockResolvedValueOnce(createJsonResponse(buildPriceListPayload()))
       .mockResolvedValueOnce(createJsonResponse(buildPriceListPayload()));
 
     const report = await apiContracts.runContractChecks({ now: new Date('2026-03-09T12:00:00.000Z') });


### PR DESCRIPTION
Expands the LiveCoinWatch contract canary to validate all preset coins across the USD and EUR top-200 price lists without per-coin fanout.
Tightens the existing keyed BTC history check to catch non-positive rates, out-of-range points, and non-increasing timestamps.
Updates the API contract tests and market-data docs to reflect the new call budget and monitoring scope.
Validated with `npm test -- --runInBand`, `npm run test:api-contracts`, and `npm run eslint`.